### PR TITLE
remove LanguageClient-neovim

### DIFF
--- a/vim_plugins/LanguageClient-neovim
+++ b/vim_plugins/LanguageClient-neovim
@@ -1,4 +1,0 @@
-{
-  "origin": "git@github.com:autozimu/LanguageClient-neovim.git",
-  "version": "20220607.1686.cf6dd11b"
-}


### PR DESCRIPTION
It doesn't work out of the box. It looks like it requires a separate installation step, and I don't know that I need the plugin.