### PR TITLE
re-sync mba

### DIFF
--- a/bin/go
+++ b/bin/go
@@ -63,9 +63,13 @@ _sync() (
   done
 )
 
+_show() (
+  while true; do go sync; sleep 3; git --no-pager diff; done
+)
+
 _main() (
   case "${1:-}" in
-    help|sync)
+    help|sync|show)
       _$1
       ;;
     *)

--- a/brew_versions
+++ b/brew_versions
@@ -1,13 +1,13 @@
 age 1.2.0
 bash 5.2.26
 bash-completion 1.3_3
-ca-certificates 2024-03-11
+ca-certificates 2024-07-02
 capstone 5.0.1
 colima 0.6.9
 coreutils 9.5
 direnv 2.34.0
-docker 27.0.2
-docker-completion 27.0.2
+docker 27.0.3
+docker-completion 27.0.3
 dtc 1.7.0
 fontconfig 2.15.0
 freetype 2.13.2
@@ -56,7 +56,7 @@ openssl@3 3.3.1
 p11-kit 0.25.3
 pcre 8.45
 pcre2 10.44
-pinentry 1.3.0
+pinentry 1.3.1
 pixman 0.42.2
 python@3.12 3.12.4
 qemu 9.0.1
@@ -64,7 +64,7 @@ readline 8.2.10
 snappy 1.2.1
 sqlite 3.46.0
 tmux 3.4_1
-tree 2.1.1_1
+tree 2.1.2
 unbound 1.20.0
 utf8proc 2.9.0
 vde 2.3.3
@@ -74,4 +74,5 @@ xz 5.4.6
 zsh 5.9
 zstd 1.5.6
 macvim 179
-rectangle 0.57,63
+qlmarkdown 1.0.17
+rectangle 0.80

--- a/home/bin/reset-nix
+++ b/home/bin/reset-nix
@@ -19,24 +19,29 @@ ifchmod() (
   fi
 )
 
-echo "Removing Nix configuration"
+echo "Removing Nix"
 for f in $HOME/{.nix-channels,.nix-defexpr,.nix-profile,.config/nixpkgs,.cache/nix,.local/state/nix}; do
   ifrm $f
 done
 
-echo "Removing Nix store"
 ifchmod /nix/store
 ifrm /nix/store
 ifrm /nix/var
+
+case $(uname -sm) in
+  "Darwin arm64")
+    platform=aarch64-darwin
+    ;;
+esac
 
 echo "Installing fresh Nix"
 (
   set -euo pipefail
   cd $(mktemp -d)
-  curl https://releases.nixos.org/nix/nix-2.10.3/nix-2.10.3-aarch64-darwin.tar.xz > tarball
+  curl https://releases.nixos.org/nix/nix-2.10.3/nix-2.10.3-${platform}.tar.xz > tarball
   tar xzf tarball
-  cd nix-2.10.3-aarch64-darwin
-  printf '64d\nw\n' | ed -s install
+  cd nix-2.10.3-${platform}
+  printf '64d\n230d\nw\n' | ed -s install
   ./install --no-daemon
 )
 nix upgrade-nix

--- a/home/dot/vimrc
+++ b/home/dot/vimrc
@@ -145,12 +145,15 @@ let @a='yyp:s/./=/g, '
 
 " Remove trailing whitespace
 function! RemoveTrailingWS()
-    let l:winview = winsaveview()
-    silent! %s/\s\+$//e
-    call winrestview(l:winview)
+  if exists('b:noStripWhitespace')
+    return
+  endif
+  let l:winview = winsaveview()
+  silent! %s/\s\+$//e
+  call winrestview(l:winview)
 endfunction
-
-"au BufWritePre <buffer> call RemoveTrailingWS()
+autocmd BufWritePre * call RemoveTrailingWS()
+autocmd FileType diff let b:noStripWhitespace=1
 
 " Color column 80
 hi ColorColumn ctermbg=52 guibg=darkred
@@ -247,14 +250,8 @@ endfun
 
 autocmd BufNewFile,BufRead * call s:DetectNode()
 
-" ruby indents 2 spaces
-autocmd FileType css setlocal expandtab shiftwidth=2 tabstop=2
-autocmd FileType html setlocal expandtab shiftwidth=2 tabstop=2
-autocmd FileType javascript setlocal expandtab shiftwidth=2 tabstop=2
-autocmd FileType json setlocal expandtab shiftwidth=2 tabstop=2
-autocmd FileType ruby setlocal expandtab shiftwidth=2 tabstop=2
-autocmd FileType sh setlocal expandtab shiftwidth=2 tabstop=2
-autocmd FileType zsh setlocal expandtab shiftwidth=2 tabstop=2
+" indent 2 spaces
+autocmd FileType css,html,javascript,json,ruby,sh,zsh setlocal expandtab shiftwidth=2 tabstop=2
 let g:terraform_fmt_on_save = 1
 
 " NERDTree toggle

--- a/home/dot/zshrc
+++ b/home/dot/zshrc
@@ -115,53 +115,7 @@ _gc() {
 }
 compdef _gc gc
 
-tail-gcp-instance() {
-  case $1 in
-    daml)
-      local project=da-dev-gcp-daml-language
-      ;;
-    davl)
-      local project=da-dev-pinacolada
-      ;;
-    *)
-  esac
-  local CURRENT_DATE_UTC=`date --utc -Iseconds`
-  local FILE=$(mktemp)
-  while true; do
-    sleep 1
-    gcloud logging read --project=$project "resource.type=gce_instance AND resource.labels.instance_id=$2 AND timestamp>=\"${CURRENT_DATE_UTC}\"" --format json | jq -r '.[] | .textPayload' > $FILE
-    cat $FILE | sed '/^$/d'
-    if [[ $(cat $FILE | head -n 5 | wc -l) -ne 0 ]]; then
-      CURRENT_DATE_UTC=`date --utc -Iseconds`;
-    fi
-  done
-}
-
-refresh_machines() {
-    machines=$(gcloud compute instances list --format=json --project=da-dev-gcp-daml-language | jq -c '[.[] | select (.name | startswith("ci-")) | {key: .name, value: .zone | sub (".*/"; "")}] | from_entries')
-}
-
-kill_machine() {
-    if [ -z "$machines" ]; then
-        refresh_machines
-    fi
-    for machine in $@; do
-        gcloud -q compute instances --project=da-dev-gcp-daml-language delete --zone=$(echo $machines | jq -r ".[\"$machine\"]") $machine
-    done
-}
-_kill_machine() {
-    local machine_names
-    if [ -z "$machines" ]; then
-        refresh_machines
-    fi
-    machine_names=$(echo $machines | jq -r "keys - $(echo -n $words | jq -sRc 'split(" ")') | .[]")
-    _arguments "*: :($machine_names)"
-}
-compdef _kill_machine kill_machine
-
-if [ -e /Users/garyverhaegen/.nix-profile/etc/profile.d/nix.sh ]; then . /Users/garyverhaegen/.nix-profile/etc/profile.d/nix.sh; fi # added by Nix installer
-
-git_large() (
+git-large() (
     git rev-list --objects --all |
     git cat-file --batch-check='%(objecttype) %(objectname) %(objectsize) %(rest)' |
     sed -n 's/^blob //p' |
@@ -170,7 +124,4 @@ git_large() (
     $(command -v gnumfmt || echo numfmt) --field=2 --to=iec-i --suffix=B --padding=7 --round=nearest
 )
 
-if [ -e $HOME/.nix-profile/etc/profile.d/nix.sh ]; then . $HOME/.nix-profile/etc/profile.d/nix.sh; fi # added by Nix installer
-
-if [ -e /Users/gary/.nix-profile/etc/profile.d/nix.sh ]; then . /Users/gary/.nix-profile/etc/profile.d/nix.sh; fi # added by Nix installer
-if [ -e /home/gary/.nix-profile/etc/profile.d/nix.sh ]; then . /home/gary/.nix-profile/etc/profile.d/nix.sh; fi # added by Nix installer
+f=$HOME/.nix-profile/etc/profile.d/nix.sh; if [ -f $f ]; then . $f; fi

--- a/tool_versions
+++ b/tool_versions
@@ -1,3 +1,3 @@
 nix (Nix) 2.18.4
 2.34.0
-Homebrew 4.3.7
+Homebrew 4.3.8


### PR DESCRIPTION
- add "go show" command
- bump nix & brew
- install age
- remove tail-gcp-instance & kill_machines from zshrc (take other changes)
- take gitconfig changes
- combine trailing whitespace removal, take other vimrc changes
- reset-nix is now platform-specific (for one platform) and does not edit zshrc, so zshrc can be more generic (i.e. use $HOME)
- take init-nix changes
- sync brew tools with mba (which I hadn't done yet)