### PR TITLE
init-nix: supportfor nix flakes

### DIFF
--- a/home/bin/init-nix
+++ b/home/bin/init-nix
@@ -10,6 +10,7 @@ fi
 cat <<'EOF' > shell.nix
 let
   pkgs = import ./nix/nixpkgs.nix;
+  getFlake = url: (builtins.getFlake url).packages.${pkgs.system}.default;
 in
 pkgs.mkShell {
   LOCALE_ARCHIVE = if pkgs.stdenv.isLinux then "${pkgs.glibcLocales}/lib/locale/locale-archive" else "";
@@ -22,6 +23,7 @@ pkgs.mkShell {
 EOF
 
 cat <<'EOF' > .envrc
+export NIX_CONFIG="experimental-features = nix-command flakes"
 use nix
 
 PATH_add bin


### PR DESCRIPTION
The Nix world is slowly moving towards nix flakes, and while most applications are still available through nixpkgs, we are starting to see some apps only available through flakes.

This makes it easy to consume flakes with e.g.

```nix
  buildInputs = with pkgs; [
    bash
    curl
    jq
    (getFlake "github:nextjournal/garden-cli")
  ];
```