### PR TITLE
vim: backupcopy

### DIFF
--- a/home/dot/vimrc
+++ b/home/dot/vimrc
@@ -85,6 +85,7 @@ else
   set autoindent
 endif
 set backup
+set backupcopy=yes
 function! InitBackupDir()
     let separator = "."
     let parent = $HOME .'/' . separator . 'vim/'


### PR DESCRIPTION
This option tells Vim to always update files in-place.

In the default behavious, when asked to write a file (typically with `:w`), Vim will start by checking how many links this file has.

On a unix filesystem, files are identified by their inode number, and links are file paths that point to a given inode.

It is possible for multiple links to point to the same inode, i.e. file.

If more than one link points to the inode we are trying to change, Vim will change it in-place, i.e. it will physically edit the piece of the hard drive this inode points to. If, however, there is only one link pointing to the inode, Vim will start by creating a new file, then update the link to point to the new inode.

In practice, the tradeoff is:

- Changing the inode a link points to is an aotmic operation, so other programs cannot see an intermediate state of the file.
- On the other hand, other files that have a file open have it open by inode, so the atomic swap would keep the old file on disk (and possibly in memory) for as long as a program keeps a hold of it, and other programs never see the new content unless they close and reopen the link.

With this option we have consistent behaviour: we always update the file in-place. Hopefully that's always what we want.