### PR TITLE
direnv: watch src.json

### DIFF
--- a/home/bin/init-nix
+++ b/home/bin/init-nix
@@ -26,6 +26,7 @@ EOF
 cat <<'EOF' > .envrc
 export NIX_CONFIG="experimental-features = nix-command flakes"
 use nix
+watch_file nix/src.json
 
 PATH_add bin
 


### PR DESCRIPTION
With this option, when src.json is changed, direnv will automatically detect it and reload the Nix environment.

Prviously, after changing src.json, I needed to `cd` out and back in to use the new Nixpkgs revision.