### PR TITLE
zsh: pick a commit

### DIFF
--- a/home/dot/zshrc
+++ b/home/dot/zshrc
@@ -137,4 +137,15 @@ _rr() {
 }
 compdef _rr rr
 
+pick() (
+  set -euo pipefail
+  ret=$(git rev-parse --abbrev-ref HEAD)
+  sha=$1
+  remote_branch=$2
+  git checkout origin/main
+  git cherry-pick $sha
+  git push origin HEAD:refs/heads/$remote_branch
+  git checkout $ret
+)
+
 f=$HOME/.nix-profile/etc/profile.d/nix.sh; if [ -f $f ]; then . $f; fi


### PR DESCRIPTION
When working with a git repo, I sometimes work with a single branch locally, so I can see the result of my combined changes, but want to make separate PRs for each change individually.

The `pick a b` command will checkout `origin/main`, cherry-pick the `a` commit on top of it, and push the result to the `origin/b` branch. If everything went well, it then moves us back to where we were.

There is currently no error handling: if something goes wrong, the user is left wherever somthing went wrong and has to clean up themselves. (Typically: `git cherry-pick --abort` followed by `git checkout wherever-you-were`.)