### PR TITLE
tmux: explicitly set escape-time

### DIFF
--- a/home/dot/tmux.conf
+++ b/home/dot/tmux.conf
@@ -51,3 +51,6 @@ setw -g clock-mode-style 24
 
 # Setting TERM variable
 set -g default-terminal "screen-256color"
+
+# 3.5 changed the default value to 10ms
+set -g escape-time 500


### PR DESCRIPTION
`escape-time` is the number of milliseconds tmux will wait after registering the ESCkey to see whether it's a standalone escape or part of a combination of keys.

I frequently use the ESC-arrow combinations, and my reflexes are not fast enough for the new default value. `500` might be a tad too long, though; I'll see how things go with more sue.