### PR TITLE
nix: default nixpkgs

### DIFF
--- a/bin/update-nixpkgs
+++ b/bin/update-nixpkgs
@@ -26,3 +26,5 @@ jq -n \
    --arg sha $archive_sha \
    '{$branch, $repo, $owner, $commit, $sha}' \
    > $DIR/../nix/src.json
+
+cat $DIR/../nix/src.json > $DIR/../home/dot/default/src.json

--- a/home/bin/init-nix
+++ b/home/bin/init-nix
@@ -2,6 +2,12 @@
 
 set -euo pipefail
 
+LINK_DEFAULT=no
+DEFAUT_SRC="$HOME/.default/nixpkgs.json"
+if [ "${1:-}" = "--default"] && [ -f "$DEFAULT_SRC" ]; then
+  LINK_DEFAULT=yes
+fi
+
 if [ -e .envrc ] || [ -e .envrc.private ] || [ -e nix ] || [ -e shell.nix ] || [ -e bin/update-nixpkgs ]; then
   echo "Conflict. Aborting."
   exit 1
@@ -96,5 +102,9 @@ in
   }) {}
 EOF
 
-echo '{"branch":"nixpkgs-unstable","repo":"nixpkgs","owner":"NixOS"}' > nix/src.json
-nix-shell -p jq -p curl --run bin/update-nixpkgs
+if [ "yes" = "$LINK_DEFAULT" ]; then
+  ln "$DEFAULT_SRC" nix/src.json
+else
+  echo '{"branch":"nixpkgs-unstable","repo":"nixpkgs","owner":"NixOS"}' > nix/src.json
+  nix-shell -p jq -p curl --run bin/update-nixpkgs
+fi

--- a/home/bin/nix-default
+++ b/home/bin/nix-default
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DEFAUT_SRC="$HOME/.default/nixpkgs.json"
+
+if [ -f "$DEFAULT_SRC" ] && [ -d nix ]; then
+  rm -f nix/src.json
+  ln "$DEFAULT_SRC" nix/src.json
+fi

--- a/home/dot/default/nixpkgs.json
+++ b/home/dot/default/nixpkgs.json
@@ -1,0 +1,7 @@
+{
+  "branch": "nixpkgs-unstable",
+  "repo": "nixpkgs",
+  "owner": "NixOS",
+  "commit": "2d2a9ddbe3f2c00747398f3dc9b05f7f2ebb0f53",
+  "sha": "1v6gpivg8mj4qapdp0y5grapnlvlw8xyh5bjahq9i50iidjr3587"
+}

--- a/home/dot/default/src.json
+++ b/home/dot/default/src.json
@@ -1,0 +1,7 @@
+{
+  "branch": "nixpkgs-unstable",
+  "repo": "nixpkgs",
+  "owner": "NixOS",
+  "commit": "31d66ae40417bb13765b0ad75dd200400e98de84",
+  "sha": "0fwsqd05bnk635niqnx9vqkdbinjq0ffdrbk66xllfyrnx4fvmpc"
+}


### PR DESCRIPTION
This adds the option of having a "default" nixpkgs version for a given user. This somewhat reduces the burden of having to explicitly call `update-nix` in multiple projects, and reducs the total disk space used by Nix as it improves the chances that multiple projects will be using the same versions.

I am not entirely sure how this will interact with git, which seems to tend to replace files rather than update them in place.