### PR TITLE
nix-default: fix typo again

### DIFF
--- a/home/bin/nix-default
+++ b/home/bin/nix-default
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-DEFAUT_SRC="$HOME/.default/nixpkgs.json"
+DEFAULT_SRC="$HOME/.default/nixpkgs.json"
 
 if [ -f "$DEFAULT_SRC" ] && [ -d nix ]; then
   rm -f nix/src.json


### PR DESCRIPTION
Different instance of the same typo.