### PR TITLE
init-nix: move arguments out of nixpkgs.nix

### DIFF
--- a/home/bin/init-nix
+++ b/home/bin/init-nix
@@ -15,7 +15,7 @@ fi
 
 cat <<'EOF' > shell.nix
 let
-  pkgs = import ./nix/nixpkgs.nix;
+  pkgs = import ./nix/nixpkgs.nix {};
   getFlake = url: (builtins.getFlake url).packages.${pkgs.system}.default;
 in
 pkgs.mkShell {
@@ -100,7 +100,7 @@ in
   import (builtins.fetchTarball {
     url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.commit}.tar.gz";
     sha256 = spec.sha;
-  }) {}
+  })
 EOF
 
 if [ "yes" = "$LINK_DEFAULT" ]; then


### PR DESCRIPTION
Having the argument (here, the empty map `{}`) outside the file has two advantages:
- It means we can give the arguments directly in `shell.nix` when we have to set one.
- This is what Nix packages / scripts are generally expecting when doing `import <nixpkgs>`, which happens quite frequently.