### PR TITLE
init-nix: fix typo

### DIFF
--- a/home/bin/init-nix
+++ b/home/bin/init-nix
@@ -4,7 +4,7 @@ set -euo pipefail
 
 LINK_DEFAULT=no
 DEFAULT_SRC="$HOME/.default/nixpkgs.json"
-if [ "${1:-}" = "--default"] && [ -f "$DEFAULT_SRC" ]; then
+if [ "${1:-}" = "--default" ] && [ -f "$DEFAULT_SRC" ]; then
   LINK_DEFAULT=yes
 fi
 


### PR DESCRIPTION
Introduced in #56; note that `]` is technically not syntax in Bash, so without the space this is equivalent to:

```bash
if [ "${1:-}" = "--default]" && [ -f "$DEFAULT_SRC" ]; then
```

I don't know what happened with #56, but this is the third PR I'm making to fix it, and there's another one coming right after. I guess I was a bit tired that day. :thinking: