### PR TITLE
default-nix: remove src.json

### DIFF
--- a/home/dot/default/src.json
+++ b/home/dot/default/src.json
@@ -1,7 +1,0 @@
-{
-  "branch": "nixpkgs-unstable",
-  "repo": "nixpkgs",
-  "owner": "NixOS",
-  "commit": "31d66ae40417bb13765b0ad75dd200400e98de84",
-  "sha": "0fwsqd05bnk635niqnx9vqkdbinjq0ffdrbk66xllfyrnx4fvmpc"
-}


### PR DESCRIPTION
It's not used. I guess at some point during the development of #56 I switched the name, but then forgot to remove the old one? I don't remember. Point is, only `default/nixpkgs.json` is used.