### PR TITLE
init-nix: close brace

### DIFF
--- a/home/bin/init-nix
+++ b/home/bin/init-nix
@@ -40,7 +40,7 @@ source_env_if_exists .envrc.private
 
 # If using Python, uncomment to get direnv to activate venv - otherwise, delete
 # lock=$(sha256sum requirements.txt 2>&1)
-# if ! [ -f .venv/lock ] || [ "$(cat .venv/lock)" != "$lock"; then (
+# if ! [ -f .venv/lock ] || [ "$(cat .venv/lock)" != "$lock" ]; then (
 #   rm -rf .venv
 #   python3 -m venv .venv
 #   source .venv/bin/activate


### PR DESCRIPTION
This is not, strictly speaking, needed: in Bash, `[]` is not syntax. Instead, `[` is the name of a program, and `]` is just a string the `[` program knows to ignore.