### PR TITLE
vim: more clojure keywords

### DIFF
--- a/home/dot/vimrc
+++ b/home/dot/vimrc
@@ -215,6 +215,8 @@ autocmd FileType clojure setlocal lispwords+=match
 autocmd FileType clojure setlocal lispwords+=mdo
 autocmd FileType clojure setlocal lispwords+=form-to
 autocmd FileType clojure setlocal lispwords+=try
+autocmd FileType clojure setlocal lispwords+=vatch
+autocmd FileType clojure setlocal lispwords+=are
 let g:clojure_fuzzy_indent_patterns = ['^with', '^def', '^let', '^match$']
 
 "Navigate to token


### PR DESCRIPTION
These are words that indent differently, i.e. functions or macros where the first argument is significantly different than the other ones.

When all the arguments are at the same coneptual level, we want them aligned:

```clojure
(+ 1
   2
   3)
```

But when they're not, we don't:

```clojure
(def msg
  "hello") ; <-- not indented at the same level as msg
```