### PR TITLE
shell.nix: better way to include certs

### DIFF
--- a/home/bin/init-nix
+++ b/home/bin/init-nix
@@ -19,10 +19,10 @@ let
   getFlake = url: (builtins.getFlake url).packages.${pkgs.system}.default;
 in
 pkgs.mkShell {
-  SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
   LOCALE_ARCHIVE = if pkgs.stdenv.isLinux then "${pkgs.glibcLocales}/lib/locale/locale-archive" else "";
   buildInputs = with pkgs; [
     bash
+    cacert
     curl
     jq
   ];


### PR DESCRIPTION
On a recent project, the previous way didn't seem to work. Doing some
research on the internet led me to [this], which explains that there are
two variables to set, but more importantly that explicitly including the
package (rather than implicitly through expanding a path, as I did
before this PR) adds the expected env vars.

Since the existing way used to work but doesn't seem to anymore, I'm
guessing including the package will be more future-proof as it will be
kept up-to-date with whatever changes the Nix team decides to make.

[this]: https://fzakaria.com/2025/02/28/nix-migraines-nix-ssl-cert-file