### PR TITLE
close `brew install` stdin

### DIFF
--- a/bin/go
+++ b/bin/go
@@ -113,16 +113,12 @@ _install() (
   brew update
   while IFS= read -r line; do
     formula=$(echo "$line" | cut -f1 -d' ')
-    version=$(echo "$line" | cut -f2 -d' ')
-    echo brew install $formula@$version
-    brew install $formula
+    brew install $formula < /dev/null
   done < brew_leaves
   if [ $(uname) = Darwin ]; then
     while IFS= read -r line; do
       formula=$(echo "$line" | cut -f1 -d' ')
-      version=$(echo "$line" | cut -f2 -d' ')
-      echo brew install --cask $formula@$version
-      brew install --cask $formula
+      brew install --cask $formula < /dev/null
     done < brew_casks
   fi
 


### PR DESCRIPTION
In the

```
  while IFS= read -r line; do
    do_body
  done < file
```

pattern, the redirection of stdin to `file` affects _the whole loop and all of its subprocesses_. So if `do_body` _also_ reads from its own stdin, it actually consumes content from `file`, which is then no longer available for the loop itself.

But we can solve this by specifically redirecting the stdin of
subcommands. In:

```
  while IFS= read -r line; do
    do_body < other_file
  done < file
```

the `do_body` subprocess has its stdin redirected to `other_file`, and
will thus not be consuming content from `file` if it happens to read
from its stdin for whatever reason.

`/dev/null` is a standard UNIX "fake file" that always returns "you've
reached the end of file" when read.

(It just so happens that `brew install git` runs the `git` installer,
which itself reads from stdin.)