### PR TITLE
zsh: prs & pick without gh token

### DIFF
--- a/home/dot/zshrc
+++ b/home/dot/zshrc
@@ -141,10 +141,24 @@ _rr() {
 }
 compdef _rr rr
 
+__gh_available() (
+  command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1
+)
+
+__github_repo_url() (
+  set -euo pipefail
+  git remote get-url origin | sed -E 's#^git@github\.com:#https://github.com/#; s#\.git$##'
+)
+
 open_pr() (
   set -euo pipefail
   head=$1
   base=$2
+  if ! __gh_available; then
+    echo "gh unavailable or not authenticated; open the PR manually:" >&2
+    echo "$(__github_repo_url)/compare/$base...$head"
+    return 0
+  fi
   resp=$(gh api -XPOST '/repos/{owner}/{repo}/pulls' \
                 -f head=$head \
                 -f base=$base \


### PR DESCRIPTION
Without a GH API token, or without `gh` installed, those two commands currently fail. With this PR, they degrade gracefully: instead of having `gh` create the PR directly, they print the URL for creating the PR, still saving a little bit of time & effort to the human (especially in the case of stacked PRs).